### PR TITLE
Use standard logging methods

### DIFF
--- a/molecule_goss/goss.py
+++ b/molecule_goss/goss.py
@@ -134,7 +134,7 @@ class Goss(Verifier):
         self._config.provisioner.verify()
 
         msg = "Verifier completed successfully."
-        LOG.success(msg)
+        LOG.info(msg)
 
     def _get_tests(self):
         """


### PR DESCRIPTION
changing log level from success to info. Has now the same behavior as ansible or testinfra verifier.