### PR TITLE
Use cookiecutter via tox to clone verify playbook

### DIFF
--- a/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -1,8 +1,4 @@
 ---
-# This is an example playbook to execute goss tests.
-# Tests need distributed to the appropriate ansible host/groups
-# prior to execution by `goss validate`.
-
 {% raw -%}
 - name: Verify
   hosts: all

--- a/molecule_goss/test/scenarios/docker/centos7/molecule/default/tests/test_default.yml
+++ b/molecule_goss/test/scenarios/docker/centos7/molecule/default/tests/test_default.yml
@@ -1,0 +1,8 @@
+# Molecule managed
+
+---
+file:
+  /etc/hosts:
+    exists: true
+    owner: root
+    group: root

--- a/molecule_goss/test/scenarios/docker/centos7/molecule/default/tests/test_install.yml
+++ b/molecule_goss/test/scenarios/docker/centos7/molecule/default/tests/test_install.yml
@@ -1,6 +1,7 @@
 ---
 file:
-  /etc/hosts:
+  /usr/local/bin/goss:
     exists: true
     owner: root
     group: root
+    mode: "0755"

--- a/molecule_goss/test/scenarios/docker/centos7/molecule/default/verify.yml
+++ b/molecule_goss/test/scenarios/docker/centos7/molecule/default/verify.yml
@@ -1,16 +1,12 @@
 ---
-# This is an example playbook to execute goss tests.
-# Tests need distributed to the appropriate ansible host/groups
-# prior to execution by `goss validate`.
-
 - name: Verify
   hosts: all
   become: true
   vars:
-    goss_version: v0.3.7
+    goss_version: v0.3.13
     goss_arch: amd64
     goss_bin: /usr/local/bin/goss
-    goss_sha256sum: 357f5c7f2e7949b412bce44349cd32ab19eb3947255a8ac805f884cc2c326059.
+    goss_sha256sum: eb3522ff9682736ff61e2ad114de227de98debcf8a03ca66fcda3917577313e0.
     goss_test_directory: /tmp/molecule/goss
     goss_format: documentation
   tasks:
@@ -21,7 +17,7 @@
         sha256sum: "{{ goss_sha256sum }}"
         mode: 0755
 
-    - name: Create Molecule directory for test files
+    - name: Create Molecule directory for test files  # noqa 208
       file:
         path: "{{ goss_test_directory }}"
         state: directory
@@ -45,7 +41,7 @@
         msg: "{{ test_files.files }}"
         verbosity: 3
 
-    - name: Copy Goss tests to remote
+    - name: Copy Goss tests to remote  # noqa 208
       copy:
         src: "{{ item.path }}"
         dest: "{{ goss_test_directory }}/{{ item.path | basename }}"
@@ -53,11 +49,11 @@
         - "{{ test_files.files }}"
 
     - name: Register test files
-      shell: "ls {{ goss_test_directory }}/test_*.yml"
+      shell: "ls {{ goss_test_directory }}/test_*.yml"  # noqa 301
       register: test_files
 
     - name: Execute Goss tests
-      command: "{{ goss_bin }} -g {{ item }} validate --format {{ goss_format }}"
+      command: "{{ goss_bin }} -g {{ item }} validate --format {{ goss_format }}"  # noqa 301
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
       failed_when: false

--- a/molecule_goss/test/scenarios/docker/ubuntu18.04/molecule/default/tests/test_default.yml
+++ b/molecule_goss/test/scenarios/docker/ubuntu18.04/molecule/default/tests/test_default.yml
@@ -1,0 +1,8 @@
+# Molecule managed
+
+---
+file:
+  /etc/hosts:
+    exists: true
+    owner: root
+    group: root

--- a/molecule_goss/test/scenarios/docker/ubuntu18.04/molecule/default/tests/test_install.yml
+++ b/molecule_goss/test/scenarios/docker/ubuntu18.04/molecule/default/tests/test_install.yml
@@ -1,6 +1,7 @@
 ---
 file:
-  /etc/hosts:
+  /usr/local/bin/goss:
     exists: true
     owner: root
     group: root
+    mode: "0755"

--- a/molecule_goss/test/scenarios/docker/ubuntu18.04/molecule/default/verify.yml
+++ b/molecule_goss/test/scenarios/docker/ubuntu18.04/molecule/default/verify.yml
@@ -1,16 +1,12 @@
 ---
-# This is an example playbook to execute goss tests.
-# Tests need distributed to the appropriate ansible host/groups
-# prior to execution by `goss validate`.
-
 - name: Verify
   hosts: all
   become: true
   vars:
-    goss_version: v0.3.7
+    goss_version: v0.3.13
     goss_arch: amd64
     goss_bin: /usr/local/bin/goss
-    goss_sha256sum: 357f5c7f2e7949b412bce44349cd32ab19eb3947255a8ac805f884cc2c326059.
+    goss_sha256sum: eb3522ff9682736ff61e2ad114de227de98debcf8a03ca66fcda3917577313e0.
     goss_test_directory: /tmp/molecule/goss
     goss_format: documentation
   tasks:
@@ -21,7 +17,7 @@
         sha256sum: "{{ goss_sha256sum }}"
         mode: 0755
 
-    - name: Create Molecule directory for test files
+    - name: Create Molecule directory for test files  # noqa 208
       file:
         path: "{{ goss_test_directory }}"
         state: directory
@@ -45,7 +41,7 @@
         msg: "{{ test_files.files }}"
         verbosity: 3
 
-    - name: Copy Goss tests to remote
+    - name: Copy Goss tests to remote  # noqa 208
       copy:
         src: "{{ item.path }}"
         dest: "{{ goss_test_directory }}/{{ item.path | basename }}"
@@ -53,11 +49,11 @@
         - "{{ test_files.files }}"
 
     - name: Register test files
-      shell: "ls {{ goss_test_directory }}/test_*.yml"
+      shell: "ls {{ goss_test_directory }}/test_*.yml"  # noqa 301
       register: test_files
 
     - name: Execute Goss tests
-      command: "{{ goss_bin }} -g {{ item }} validate --format {{ goss_format }}"
+      command: "{{ goss_bin }} -g {{ item }} validate --format {{ goss_format }}"  # noqa 301
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
       failed_when: false

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,9 @@ commands =
     ansibledevel: ansible-galaxy install git+https://github.com/ansible-collections/community.general.git
     # failsafe as pip may install incompatible dependencies
     pip check
+    # use cookiecutter to deploy the functional test verify playbooks
+    cookiecutter -f molecule_goss/cookiecutter/ --output-dir molecule_goss/test/scenarios/docker/centos7/ --no-input
+    cookiecutter -f molecule_goss/cookiecutter/ --output-dir molecule_goss/test/scenarios/docker/ubuntu18.04/ --no-input
     # failsafe for preventing changes that may break pytest collection
     python -m pytest -p no:cov --collect-only
     python -m pytest {posargs:-l}
@@ -49,6 +52,7 @@ deps =
     py{36,37,38,39}: molecule[test]
     py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
     dockerfile: ansible>=2.9.12
+    cookiecutter
     molecule-docker
     docker>=4.3.1
 passenv =


### PR DESCRIPTION
The verify playbook for the functional tests was manually copied to each
dir. This change attempts to DRY out the setup of the tests by using
cookiecutter to clone the default playbook.