### PR TITLE
update goss version, fix ansible-lint warnings, add ability to copy defaults vars to goss vars

### DIFF
--- a/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -18,10 +18,11 @@
         checksum: "sha256:{{ goss_sha256sum }}"
         mode: 0755
 
-    - name: Create Molecule directory for test files  # noqa 208
+    - name: Create Molecule directory for test files
       file:
         path: "{{ goss_test_directory }}"
         state: directory
+        mode: 0644
 
     - name: Find Goss tests on localhost
       find:
@@ -42,10 +43,11 @@
         msg: "{{ test_files.files }}"
         verbosity: 3
 
-    - name: Copy Goss tests to remote  # noqa 208
+    - name: Copy Goss tests to remote
       copy:
         src: "{{ item.path }}"
         dest: "{{ goss_test_directory }}/{{ item.path | basename }}"
+        mode: 0644
       with_items:
         - "{{ test_files.files }}"
 

--- a/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -52,13 +52,15 @@
         - "{{ test_files.files }}"
 
     - name: Register test files
-      shell: "ls {{ goss_test_directory }}/test_*.yml"  # noqa 301
+      shell: "ls {{ goss_test_directory }}/test_*.yml"
+      changed_when: false
       register: test_files
 
     - name: Execute Goss tests
       command: "{{ goss_bin }} -g {{ item }} validate --format {{ goss_format }}"  # noqa 301
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
+      changed_when: false
       failed_when: false
 
     - name: Display details about the Goss results

--- a/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -15,7 +15,7 @@
       get_url:
         url: "https://github.com/aelsabbahy/goss/releases/download/{{ goss_version }}/goss-linux-{{ goss_arch }}"
         dest: "{{ goss_bin }}"
-        sha256sum: "{{ goss_sha256sum }}"
+        checksum: "sha256:{{ goss_sha256sum }}"
         mode: 0755
 
     - name: Create Molecule directory for test files  # noqa 208

--- a/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -65,7 +65,12 @@
       register: test_files
 
     - name: Execute Goss tests
-      command: "{{ goss_bin }} {% if copy_defaults_vars %}--vars {{ goss_vars }} {% endif %}-g {{ item }} validate --format {{ goss_format }}"
+      command:
+        "{{ goss_bin }}
+         {% if copy_defaults_vars %}
+         --vars {{ goss_vars }}
+         {% endif %}
+         -g {{ item }} validate --format {{ goss_format }}"
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
       changed_when: false

--- a/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -11,7 +11,7 @@
     goss_test_directory: /tmp/molecule/goss
     goss_format: documentation
     goss_vars: "{{ goss_test_directory }}/vars"
-    copy_defaults_vars: true
+    copy_defaults_vars: false
   tasks:
     - name: Download and install Goss
       get_url:

--- a/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -4,10 +4,10 @@
   hosts: all
   become: true
   vars:
-    goss_version: v0.3.13
+    goss_version: v0.3.16
     goss_arch: amd64
     goss_bin: /usr/local/bin/goss
-    goss_sha256sum: eb3522ff9682736ff61e2ad114de227de98debcf8a03ca66fcda3917577313e0.
+    goss_sha256sum: 827e354b48f93bce933f5efcd1f00dc82569c42a179cf2d384b040d8a80bfbfb.
     goss_test_directory: /tmp/molecule/goss
     goss_format: documentation
   tasks:

--- a/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -49,6 +49,7 @@
       copy:
         src: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/defaults/main.yml"
         dest: "{{ goss_vars }}"
+        mode: 0644
       when: copy_defaults_vars
 
     - name: Copy Goss tests to remote

--- a/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
+++ b/molecule_goss/cookiecutter/{{cookiecutter.molecule_directory}}/{{cookiecutter.scenario_name}}/verify.yml
@@ -10,6 +10,8 @@
     goss_sha256sum: 827e354b48f93bce933f5efcd1f00dc82569c42a179cf2d384b040d8a80bfbfb.
     goss_test_directory: /tmp/molecule/goss
     goss_format: documentation
+    goss_vars: "{{ goss_test_directory }}/vars"
+    copy_defaults_vars: true
   tasks:
     - name: Download and install Goss
       get_url:
@@ -43,6 +45,12 @@
         msg: "{{ test_files.files }}"
         verbosity: 3
 
+    - name: Copy defaults vars to goss vars
+      copy:
+        src: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/defaults/main.yml"
+        dest: "{{ goss_vars }}"
+      when: copy_defaults_vars
+
     - name: Copy Goss tests to remote
       copy:
         src: "{{ item.path }}"
@@ -57,7 +65,7 @@
       register: test_files
 
     - name: Execute Goss tests
-      command: "{{ goss_bin }} -g {{ item }} validate --format {{ goss_format }}"  # noqa 301
+      command: "{{ goss_bin }} {% if copy_defaults_vars %}--vars {{ goss_vars }} {% endif %}-g {{ item }} validate --format {{ goss_format }}"
       register: test_results
       with_items: "{{ test_files.stdout_lines }}"
       changed_when: false


### PR DESCRIPTION
Adds a new variable `copy_defaults_vars` set to `false`. If set to `true` the content of the roles `defaults/main.yml` are copied to the `{{ goss_test_directory }}/vars` file on the remote and `{{ goss_test_directory }}/vars` is passed to goss with --vars. The vars defined in `defaults/main.yml` can then be referenced in the test definitions, see https://github.com/aelsabbahy/goss/blob/master/docs/manual.md#templates.

