### PR TITLE
Removed ansible from install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ setup_requires =
 
 # These are required in actual runtime:
 install_requires =
-    ansible >= 2.10.3
+    # molecule plugins are not allowed to mention Ansible as a direct dependency
     molecule >= 3.2.0
     pyyaml >= 5.1, < 6
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ description =
     Unit testing
 usedevelop = True
 extras =
+    ansible
     lint
     test
 commands =
@@ -49,8 +50,8 @@ setenv =
     MOLECULE_NO_LOG=0
 deps =
     devel: ansible>=2.10.3,<2.11
-    py{36,37,38,39}: molecule[test]
-    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[test]
+    py{36,37,38,39}: molecule[ansible,test]
+    py{36,37,38,39}-{devel}: git+https://github.com/ansible-community/molecule.git@master#egg=molecule[ansible,test]
     dockerfile: ansible>=2.9.12
     cookiecutter
     molecule-docker


### PR DESCRIPTION
* Molecule requires drivers not to mention Ansible as a dependency in
order to keep itself decoupled from Ansible.

* Updated tox.ini configuration